### PR TITLE
fixes undefined index TopicName error

### DIFF
--- a/src/Subscriber/Pipeline/HasTopicName.php
+++ b/src/Subscriber/Pipeline/HasTopicName.php
@@ -14,7 +14,7 @@ class HasTopicName
      */
     public function handle($message, \Closure $next)
     {
-        if (!$message->attributes()['TopicName']) {
+        if (!array_key_exists('TopicName', $message->attributes())) {
             return;
         }
 


### PR DESCRIPTION
Messages published without a TopicName throws an error, changed so that it does not reference it unless the key exists